### PR TITLE
remove disconnected callback when disconnected

### DIFF
--- a/custom_components/ha_bedjet/climate.py
+++ b/custom_components/ha_bedjet/climate.py
@@ -301,6 +301,7 @@ class BedJet(ClimateEntity):
 
             if self.is_connected:
                 _LOGGER.info(f'Connected to {self.mac}.')
+                self.client.set_disconnected_callback(self.on_disconnect)
                 break
 
         if not self.is_connected:
@@ -316,6 +317,7 @@ class BedJet(ClimateEntity):
     def on_disconnect(self, client):
         self.is_connected = False
         _LOGGER.warning(f'Disconnected from {self.mac}.')
+        self.client.set_disconnected_callback(None)
         asyncio.create_task(self.connect_and_subscribe())
 
     async def disconnect(self):


### PR DESCRIPTION
remove the disconnected_callback as soon as the client disconnects, so that you don't end up with multiple tasks all trying to reconnect